### PR TITLE
GROUP API to update bot

### DIFF
--- a/app/api/group/create/route.ts
+++ b/app/api/group/create/route.ts
@@ -9,7 +9,16 @@ import {
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
 
-// POST method to create group
+/*
+POST method to create group and with other member
+- API POST "api/group/create"
+- header:
+    - cookie: 
+        - session
+- body: 
+    - groupName: string;
+    - Member_Emails: string;
+*/
 interface CreateGroupRequest {
     // ownerID: number;
     groupName: string;

--- a/app/api/group/delete/route.ts
+++ b/app/api/group/delete/route.ts
@@ -9,7 +9,15 @@ import {
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
 
-// DELETE method to delete group owned by user
+/*
+DELETE method to delete group
+- API DELETE "api/group/delete"
+- params:
+    - groupID: number
+- header:
+    - cookie: 
+        - session
+*/
 export async function DELETE(request: NextRequest) {
     // Get session to authenticate and secure api 
     const authSession = await getSession(request);

--- a/app/api/group/route.ts
+++ b/app/api/group/route.ts
@@ -8,7 +8,13 @@ import {
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
 
-// Get method to fetch groups for a user
+/*
+GET method to fetch groups for a user
+- API POST "api/group"
+- header:
+    - cookie: 
+        - session
+*/
 export async function GET( request: NextRequest ): Promise<NextResponse> {
 
     // Get session to authenticate and secure api 

--- a/app/api/group/update_bots/route.ts
+++ b/app/api/group/update_bots/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest,NextResponse } from 'next/server';
+import { 
+    collection, 
+    getDocs, 
+    query, 
+    where, 
+    updateDoc
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase/app';
+import { GET as getSession } from '@/app/api/session/route'
+
+// PUT method to update shared member email
+interface UpdateGroupRequest {
+    // userID: number;
+    groupIDs: number[];
+    botID: number;
+}
+
+export async function PUT(request: NextRequest) {
+    // Get session to authenticate and secure api 
+    const authSession = await getSession(request);
+    if (!(authSession.ok)){
+        return authSession;
+    };
+    
+    const { userId : userID, email } = await authSession.json();
+    const body: UpdateGroupRequest = await request.json();
+    const { groupIDs, botID } = body;
+
+    try{
+        // get groups by id
+        const groupsRef = collection(db, 'groups');
+        const groupsQuery = query(groupsRef, where('groupID', 'array-contains-any', groupIDs));
+        const snapshotGroups = await getDocs(groupsQuery);
+
+        // get bot by id
+        const botsRef = collection(db, 'groups');
+        const botsQuery = query(groupsRef, where('botID', '==', botID));
+        const snapshotBots = await getDocs(botsQuery);
+        const botAgent = snapshotBots.docs[0]; // only get one bot
+
+        if (snapshotGroups.empty) {
+            return NextResponse.json({ 
+                message: 'Group not found!',
+                body
+            }, { status: 404 });
+        }
+
+        // update group
+        snapshotGroups.forEach(snapshot => {
+            if (userID === snapshot.data().ownerID || 
+                email === snapshot.data().sharedMembersEmail ||
+                userID === botAgent.data().ownerID){
+
+                    let sharedBotsID = snapshot.data().sharedBotsID.empty ? [] : snapshot.data().sharedBotsID.empty ;
+
+                    sharedBotsID.push(botID);
+
+                    updateDoc(snapshot.ref, {
+                        sharedBotsID: sharedBotsID,
+                    });
+            }
+        })
+
+        return NextResponse.json({ 
+            message: 'Update successful!',
+        }, { status: 200 });
+
+    } catch (error) {
+        console.log(`Error updating group: ${error}`);
+    }
+    return NextResponse.json({ 
+        message: 'Update group failed with error',
+    }, { status: 500 });
+}

--- a/app/api/group/update_bots/route.ts
+++ b/app/api/group/update_bots/route.ts
@@ -4,12 +4,20 @@ import {
     getDocs, 
     query, 
     where, 
-    updateDoc
+    updateDoc,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
-
-// PUT method to update shared member email
+/*
+PUT method to update shared bot
+- API PUT "api/group/update_bots"
+- header:
+    - cookie: 
+        - session
+- body: 
+    - groupIDs: number[];
+    - botID: number;
+*/
 interface UpdateGroupRequest {
     // userID: number;
     groupIDs: number[];
@@ -46,13 +54,18 @@ export async function PUT(request: NextRequest) {
             }, { status: 404 });
         }
 
+        if (userID === botAgent.data().ownerID) {
+            return NextResponse.json({ 
+                message: 'You are not the owner of this bot!',
+            }, { status: 403 });
+        }
+
         // update group
         snapshotGroups.forEach(snapshot => {
             if (userID === snapshot.data().ownerID || 
-                email === snapshot.data().sharedMembersEmail ||
-                userID === botAgent.data().ownerID){
-
-                    let sharedBotsID = snapshot.data().sharedBotsID.empty ? [] : snapshot.data().sharedBotsID.empty ;
+                email === snapshot.data().sharedMembersEmail
+            ){
+                    let sharedBotsID: Number[] = snapshot.data().sharedBotsID.empty ? [] : snapshot.data().sharedBotsID ;
 
                     sharedBotsID.push(botID);
 

--- a/app/api/group/update_members/route.ts
+++ b/app/api/group/update_members/route.ts
@@ -11,7 +11,7 @@ import { GET as getSession } from '@/app/api/session/route'
 
 // PUT method to update shared member email
 interface UpdateGroupRequest {
-    userID: number;
+    // userID: number;
     groupID: number;
     Member_Emails: string;
 }

--- a/app/api/group/update_members/route.ts
+++ b/app/api/group/update_members/route.ts
@@ -9,7 +9,16 @@ import {
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
 
-// PUT method to update shared member email
+/*
+PUT method to update member's emails
+- API PUT "api/group/update_members"
+- header:
+    - cookie: 
+        - session
+- body: 
+    - groupName: string;
+    - Member_Emails: string;
+*/
 interface UpdateGroupRequest {
     // userID: number;
     groupID: number;


### PR DESCRIPTION
add an api to update group's bot
*Done:*
- [x] Authenticate & secure with session cookie.
- [x]  update a bot to many group (suitable and optimized for the current interface design). 


PUT method to update shared bot
- API PUT "api/group/update_bots"
- header:
    - cookie: 
        - session
- body: 
    - groupIDs: number[];
    - botID: number;