### PR TITLE
fix api/group/update_bots remove bot from groups that are not shared with

### DIFF
--- a/app/account/bots/page.tsx
+++ b/app/account/bots/page.tsx
@@ -193,7 +193,7 @@ export default function Bots() {
                   </p>
 
                   <div className="flex gap-2">
-                    <Link href={`/account/bots/${bot.id}`} className="flex-1">
+                    <Link href={`/account/bots/${bot.botID}`} className="flex-1">
                       <Button
                         variant="outline"
                         className="w-full"

--- a/app/api/group/update_bots/route.ts
+++ b/app/api/group/update_bots/route.ts
@@ -8,7 +8,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
-import { ReceiptTurkishLiraIcon } from 'lucide-react';
+
 /*
 PUT method to update shared bot
 - API PUT "api/group/update_bots"
@@ -58,7 +58,7 @@ export async function PUT(request: NextRequest) {
 
             if (snapshotBots.empty) {
                 return NextResponse.json({ 
-                    message: 'Bot not found!',
+                    message: 'Bot not found!'+`\nbotID: ${botID}`,
                     body
                 }, { status: 404 });
             }
@@ -88,8 +88,6 @@ export async function PUT(request: NextRequest) {
                 }
             })
         }
-
-        
 
         // stop shared bot with some groups
         const stopSharedGroupsQuery = query(groupsRef, where('sharedBotID', 'array-contains', botID));

--- a/app/api/group/update_bots/route.ts
+++ b/app/api/group/update_bots/route.ts
@@ -8,6 +8,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase/app';
 import { GET as getSession } from '@/app/api/session/route'
+import { ReceiptTurkishLiraIcon } from 'lucide-react';
 /*
 PUT method to update shared bot
 - API PUT "api/group/update_bots"
@@ -35,45 +36,46 @@ export async function PUT(request: NextRequest) {
     const body: UpdateGroupRequest = await request.json();
     const { groupIDs, botID } = body;
 
+    const groupsRef = collection(db, 'groups');
+
     try{
-        // get groups by id
-        const groupsRef = collection(db, 'groups');
-        const groupsQuery = query(groupsRef, where('groupID', 'in', groupIDs));
-        const snapshotGroups = await getDocs(groupsQuery);
+        if (groupIDs.length > 0){
+            // get groups by id
+            const groupsQuery = query(groupsRef, where('groupID', 'in', groupIDs));
+            const snapshotGroups = await getDocs(groupsQuery);
+            if (snapshotGroups.empty) {
+                return NextResponse.json({ 
+                    message: 'Group not found!',
+                    body
+                }, { status: 404 });
+            }
 
-        if (snapshotGroups.empty) {
-            return NextResponse.json({ 
-                message: 'Group not found!',
-                body
-            }, { status: 404 });
-        }
+            // get bot by id
+            const botsRef = collection(db, 'botConfigAgent');
+            const botsQuery = query(botsRef, where('botID', '==', botID));
+            const snapshotBots = await getDocs(botsQuery);
+            
 
-        // get bot by id
-        const botsRef = collection(db, 'botConfigAgent');
-        const botsQuery = query(botsRef, where('botID', '==', botID));
-        const snapshotBots = await getDocs(botsQuery);
-        
+            if (snapshotBots.empty) {
+                return NextResponse.json({ 
+                    message: 'Bot not found!',
+                    body
+                }, { status: 404 });
+            }
+            
+            const botAgent = snapshotBots.docs[0]; // only get one bot
 
-        if (snapshotBots.empty) {
-            return NextResponse.json({ 
-                message: 'Bot not found!',
-                body
-            }, { status: 404 });
-        }
-        
-        const botAgent = snapshotBots.docs[0]; // only get one bot
+            if (userID !== botAgent.data().owner) {
+                return NextResponse.json({ 
+                    message: 'You are not the owner of this bot!',
+                }, { status: 403 });
+            }
 
-        if (userID !== botAgent.data().owner) {
-            return NextResponse.json({ 
-                message: 'You are not the owner of this bot!',
-            }, { status: 403 });
-        }
-
-        // update group
-        snapshotGroups.forEach(snapshot => {
-            if (userID === snapshot.data().ownerID || 
-                snapshot.data().sharedMembersEmail.includes(email)
-            ){
+            // update group
+            snapshotGroups.forEach(snapshot => {
+                if (userID === snapshot.data().ownerID || 
+                    snapshot.data().sharedMembersEmail.includes(email)
+                ){
                     let sharedBotID: Number[] = snapshot.data().sharedBotID.empty ? [] : snapshot.data().sharedBotID ;
 
                     if (sharedBotID.includes(botID) ) return;
@@ -83,7 +85,26 @@ export async function PUT(request: NextRequest) {
                     updateDoc(snapshot.ref, {
                         sharedBotID: sharedBotID,
                     });
-            }
+                }
+            })
+        }
+
+        
+
+        // stop shared bot with some groups
+        const stopSharedGroupsQuery = query(groupsRef, where('sharedBotID', 'array-contains', botID));
+        const snapshotStopSharedGroups = await getDocs(stopSharedGroupsQuery);
+
+        if (!snapshotStopSharedGroups.empty)
+        snapshotStopSharedGroups.forEach(snapshot => {
+            if (groupIDs.includes(snapshot.data().groupID)) return;
+            let sharedBotID: Number[] = snapshot.data().sharedBotID.empty ? [] : snapshot.data().sharedBotID ;
+            sharedBotID = sharedBotID.filter(botId => botId !== botID);
+
+            updateDoc(snapshot.ref, {
+                sharedBotID: sharedBotID,
+            });
+            
         })
 
         return NextResponse.json({ 
@@ -91,8 +112,9 @@ export async function PUT(request: NextRequest) {
         }, { status: 200 });
 
     } catch (error) {
-        console.log(`Error updating group: ${error}`);
+        console.log(`Error updating share bot with group: ${error}`);
     }
+
     return NextResponse.json({ 
         message: 'Update group failed with error',
     }, { status: 500 });


### PR DESCRIPTION
### UI
- Share bot with group in Edit Bot Page.
- Displayed all groups contain bot below **Share** button.
- How to share bot:
  - Click **Share** button
  - Check groups you want to share with.
  - Click **Share**.
  - 
### API
PUT method to update shared bot
API PUT "api/group/update_bots"
- header:
  - cookie:
    - session
- body:
  - groupIDs: number[];
  - botID: number;

Typescript/ Javascipt:
```javascript
const botID;    // = <the bot's ID needs to be shared>;
const groupIDs; // = [<list of groups>];
fetch("/api/group/update_bots", {
  method: "PUT",
  headers: {
    "Content-Type": "application/json"
  },
  body: JSON.stringify({
    botID: botID,
    groupIDs: groupIDs
  })
});
```
**NOTE:**
- if u want to remove bot from all group it was shared, just let groupIDs is an empty array (`const groupIDs = [];`)
- all group not in groupIDs will remove bot from its shared list. ex: if bot is shared with groups 1, 2, 3 and groupIDs = [1,2] => group 3 will remove bot from its shared list ( group3's shared list no longer contain that bot).

### Done:
- [x] Add bot to shared list of groups (groupIDs in api's body)
- [x] Remove bot from shared list of groups (groups not-in groupIDs)

**NotDone:**
- [ ] Clean the code.


### Any Bugs or Trouble => assign @isQHung 